### PR TITLE
Add integration with Foofle to quickly open search with element

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -5,6 +5,7 @@ Search = require "scripts.search"
 SearchResults = require "scripts.search-results"
 ResultLocation = require "scripts.result-location"
 Gui = require "scripts.gui"
+local foofle_integration = require "scripts.foofle-integration"
 
 function filtered_surfaces(override_surface, player_surface)
   if override_surface then
@@ -53,6 +54,13 @@ script.on_init(
     global.current_searches = {}
     global.multiple_surfaces = false
     update_surface_count()
+    foofle_integration.on_start()
+  end
+)
+
+script.on_load(
+  function()
+    foofle_integration.on_start()
   end
 )
 

--- a/info.json
+++ b/info.json
@@ -6,7 +6,7 @@
     "homepage": "https://discord.gg/pkJc4v9nfT",
     "description": "Search your factory for items, fluids, entities, signals, tags and more with Shift + F. Displays a list of matching buildings: clicking on a result opens it in the map. Supports Space Exploration (works across all surfaces).\nControl + Shift + Click on almost anything (e.g. built entity, inventory item, recipe) to open the search with that item selected.\nSimilar to BeastFinder and Where is it Made?",
     "factorio_version": "1.1",
-    "dependencies": ["base"],
+    "dependencies": ["base", "? foofle"],
     "package": {
       "ignore": ["resources/*", "scenarios/*"]
     }

--- a/scripts/foofle-integration.lua
+++ b/scripts/foofle-integration.lua
@@ -1,0 +1,30 @@
+local Gui = require "scripts.gui"
+
+remote.add_interface("factory-search", {
+  search = function(player, info)
+    local gui = Gui.open(player, global.players[player.index])
+    gui.refs.item_select.elem_value = {
+        type = info.type,
+        name = info.name
+    }
+    Gui.start_search(player, gui)
+  end,
+  foofle_support = function(info)
+    return info.type == "fluid" or info.type == "item"
+  end
+})
+
+local function on_start()
+  if remote.interfaces["foofle"] then
+    remote.call("foofle", "add_integration", "factory-search", {
+      button = {
+        type = "button",
+        caption = { "mod-name.FactorySearch" }
+      },
+      supported_check = "foofle_support",
+      callback = "search"
+    })
+  end
+end
+
+return { on_start = on_start }

--- a/scripts/gui.lua
+++ b/scripts/gui.lua
@@ -554,6 +554,7 @@ function Gui.open(player, player_data)
   refs.frame.visible = true
   refs.frame.bring_to_front()
   player.set_shortcut_toggled("search-factory", true)
+  return player_data
 end
 
 function Gui.destroy(player, player_data)


### PR DESCRIPTION
To try it out, install this mod: https://mods.factorio.com/mod/foofle

Then open the game, press Ctrl + Shift + S and select an area, then click on something and then click the "Factory Search"-button.

Personally I think it makes it so much easier to search the factory, as you don't necessarily have to type in the element yourself in the search box. I hope you like it too.